### PR TITLE
Season should be optional to access stats

### DIFF
--- a/src/main/java/riotapi/RiotApi.java
+++ b/src/main/java/riotapi/RiotApi.java
@@ -1367,6 +1367,9 @@ public class RiotApi {
      * @return The currently set season
      */
     public String getSeason() {
+    	if(season == null){
+    		return null;
+    	}
         return season.getName();
     }
 

--- a/src/method/StatsMethod.java
+++ b/src/method/StatsMethod.java
@@ -36,7 +36,12 @@ public final class StatsMethod {
      */
     public static PlayerStatsSummaryList getPlayerStatsSummary(String endpoint, String region, String season, String key, long summonerId) throws RiotApiException {
 
-        String url = endpoint + "/api/lol/" + region + "/v1.3/stats/by-summoner/" + summonerId + "/summary?season=" + season + "&api_key=" + key;
+        String url = endpoint + "/api/lol/" + region + "/v1.3/stats/by-summoner/" + summonerId + "/summary?";
+        if(season == null){
+        	url += "season=" + season + "&";
+        }
+        url += "api_key=" + key;
+
         PlayerStatsSummaryList summaryList = null;
 
         try {
@@ -59,7 +64,11 @@ public final class StatsMethod {
      */
     public static RankedStats getRankedStats(String endpoint, String region, String season, String key, long summonerId) throws RiotApiException {
 
-        String url = endpoint + "/api/lol/" + region + "/v1.3/stats/by-summoner/" + summonerId + "/ranked?season=" + season + "&api_key=" + key;
+        String url = endpoint + "/api/lol/" + region + "/v1.3/stats/by-summoner/" + summonerId + "/ranked?";
+        if(season == null){
+        	url += "season=" + season + "&";
+        }
+        url += "api_key=" + key;
         RankedStats rankedStats = null;
 
         try {


### PR DESCRIPTION
It is not needed to specify a season to access
/api/lol/{region}/v1.3/stats/by-summoner/{summonerId}/ranked

However the application will crash with 
NullPointerException
when trying to access it without having specified a Season, because
getSeason() = season.getName();

This should fix it.
