### PR TITLE
added "addApiKeyParameter()" in GetShardData class

### DIFF
--- a/src/main/java/net/rithms/riot/api/endpoints/lol_status/methods/GetShardData.java
+++ b/src/main/java/net/rithms/riot/api/endpoints/lol_status/methods/GetShardData.java
@@ -28,5 +28,6 @@ public class GetShardData extends LolStatusApiMethod {
 		setPlatform(platform);
 		setReturnType(ShardStatus.class);
 		setUrlBase(platform.getHost() + "/lol/status/v3/shard-data");
+		addApiKeyParameter();
 	}
 }


### PR DESCRIPTION
For some reason, the Riot API returns 401 "Unauthorized" when calling /status/v3/shard-data without an API key.
Try it:
https://na1.api.riotgames.com/lol/status/v3/shard-data