### PR TITLE
X-Rate-Limit-Type returns 'application' not 'user' when app rate limit was exceeded

### DIFF
--- a/src/main/java/net/rithms/riot/api/request/ratelimit/RateLimitList.java
+++ b/src/main/java/net/rithms/riot/api/request/ratelimit/RateLimitList.java
@@ -63,7 +63,7 @@ public class RateLimitList {
 	}
 
 	public void setRateLimit(String service, Platform platform, String type, int retryAfter) {
-		if (type.equals("user")) {
+		if (type.equals("application")) {
 			userLimits.put(platform, new RateLimit(type, retryAfter));
 		} else if (type.equals("service")) {
 			if (!serviceLimits.containsKey(platform)) {


### PR DESCRIPTION
Fixes RateLimitList.setRateLimit is checking for "user" not "application" #108.

